### PR TITLE
Fix Cutout to cut out features from tile fully inside reference geometry

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,7 @@ tile-cut
 tippecanoe-decode
 tippecanoe-enumerate
 unit
+geojson2nd
 
 # Vim
 *.swp

--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@
 *.app
 tippecanoe
 tile-join
+tile-cut
 tippecanoe-decode
 tippecanoe-enumerate
 unit

--- a/README.md
+++ b/README.md
@@ -584,6 +584,7 @@ In that case changes are applied to a newly created `mbtiles` file which is a cl
 ### Processing options
 
  * `-R` or `--delete-tiles-within-region`: Remove tiles fully contained by the region polygon at all zoom levels. [default: off]
+ * `-O` or `--delete-tiles-outside-region`: Remove tiles fully outside the region polygon at all zoom levels. [default: off]
  * `-B` or `--change-boundary-features`: Modify boundary tiles intersecting the outline of the region. [default: off]
  * `-V` or `--vacuum-mbtiles`: Compact sqlite3 database specified by --main-tileset. [default: off]
  * `-v` or `--verbose`: Show detailed process information.


### PR DESCRIPTION
This PR fixed the cutout of tippecanoe cut so it also cuts out all geometries of an affected tile. Only geometries for which all points are fully inside of reference geometry are cut out. Geometries containing points outside of Switzerland remain in the tile.